### PR TITLE
Add GMP/BCMath requirement and runtime check for hashids/hashids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,10 @@
     "require-dev": {
         "laravel/pint": "^1.21"
     },
+    "suggest": {
+        "ext-gmp": "Recommended for best performance with hashids/hashids.",
+        "ext-bcmath": "Alternative to GMP. At least one is required."
+    },
     "config": {
         "sort-packages": true
     },

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,8 @@ You can install the package via composer:
 composer require tobymaxham/laravel-hashid
 ```
 
+> This package relies on `hashids/hashids`, which requires either the GMP or BCMath extension. GMP is recommended for best performance and should be installed if possible.
+
 
 ## Configuration
 

--- a/src/HashIdServiceProvider.php
+++ b/src/HashIdServiceProvider.php
@@ -3,6 +3,7 @@
 namespace TobyMaxham\HashId;
 
 use Hashids\Hashids;
+use RuntimeException;
 use Illuminate\Support\ServiceProvider;
 
 class HashIdServiceProvider extends ServiceProvider
@@ -18,8 +19,17 @@ class HashIdServiceProvider extends ServiceProvider
         );
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function register()
     {
+        if (! \extension_loaded('gmp') && ! \extension_loaded('bcmath')) {
+            throw new RuntimeException(
+                'Missing required PHP extension: either GMP or BCMath must be installed for hashids/hashids to work.'
+            );
+        }
+
         $this->app->bind(IdHasherManager::class, function () {
             $instance = new IdHasherManager;
             $instance->setHasher(new Hashids(


### PR DESCRIPTION
### ✨ What’s changed?

- **Added `suggest` section** in `composer.json` to recommend installing `ext-gmp` or `ext-bcmath`, as `hashids/hashids` requires one of these extensions.
- **Introduced a runtime check** in the `HashIdServiceProvider` to throw a clear exception if neither extension is available.

### ❓ Why this change?

When using this package without GMP or BCMath, `hashids/hashids` will throw a `RuntimeException` during object construction:

```
Missing BC Math or GMP extension.
```

Example from the stack trace:

```
Hashids.php:getMathExtension()
```

This change ensures that users receive an **early, clear, and descriptive error**, rather than running into an unexpected exception at runtime.

### ✅ Example check:

```php
if (!extension_loaded('gmp') && !extension_loaded('bcmath')) {
    throw new \RuntimeException(
        'Missing required PHP extension. Please install either the GMP (php-gmp) or BCMath (php-bcmath) extension to use this package.'
    );
}
```

### 📌 Recommendation:

GMP is preferred for performance reasons. BCMath is accepted as a fallback.